### PR TITLE
Fixed file rename bug.

### DIFF
--- a/genesis.py
+++ b/genesis.py
@@ -2,7 +2,7 @@ import sys
 
 
 def write_stub(filepath, stub):
-    if filepath[:-3] != '.py':
+    if filepath[-3:] != '.py':
         filepath += '.py'
     with open(filepath, 'w') as f:
         f.write(stub)


### PR DESCRIPTION
Filenames passed to genesis were being appended with '.py'.  This will only happen if the last 3 characters do not equal '.py'.
