### PR TITLE
Controller command kwargs

### DIFF
--- a/Helpers/Commands.py
+++ b/Helpers/Commands.py
@@ -3,6 +3,40 @@ from Helpers import DummyLogger, DummyThread
 import threading
 
 
+class Kwargs(object):
+    """
+    An object used for passing **kwargs with your *args.
+
+    Example:
+
+    @has_kwargs
+    def some_controller_func(first_arg, second_arg, some_arg=True, other_arg='NA'):
+        print first_arg, second_arg
+        print some_arg, other_arg
+
+    a = ('hello', 'world', Kwargs({'some_arg': 'HELLO', 'other_arg': 'WORLD!!!'}))
+    some_controller_func(*a)
+
+    """
+    def __init__(self, dict):
+        self.dictionary = dict
+
+    def __len__(self):
+        return len(self.dictionary)
+
+    def __getitem__(self, key):
+        return self.dictionary[key]
+
+    def __setitem__(self, key, value):
+        self.dictionary[key] = value
+
+    def __delitem__(self, key):
+        del self.dictionary[key]
+
+    def __iter__(self):
+        return self.dictionary.iteritems()
+
+
 class BaseCommandFactory(object):
     def __init__(self, controllers, logging=False, attach_drivers=True, wait_timeout=30, log_file='main_log.txt'):
         if type(controllers) != dict:

--- a/Helpers/Controllers.py
+++ b/Helpers/Controllers.py
@@ -1,5 +1,33 @@
 from datetime import datetime
+from Helpers.Commands import Kwargs
 from selenium.webdriver.support.wait import WebDriverWait
+
+
+def has_kwargs(func):
+    """
+    Decorator for passing **kwargs with your *args through the use of
+    the Kwargs object.  Note that only 1 Kwargs object can be passed
+    with the *args to the decorated function.  Any additional Kwargs
+    objects will be ignored.
+
+    :param func:
+    :return:
+    """
+
+    def _process(*args):
+        args = list(args)
+        # Extract kwargs from args.
+        d_args = [t for t in args if type(t) == Kwargs]
+        try:
+            d_args = d_args[0]
+        except IndexError:
+            return func(*args, **{})
+        # Remove kwargs from args
+        args = [item for item in args if type(item) != Kwargs]
+        # Get args from Kwargs object.
+        kwargs = {k: v for (k, v) in d_args}
+        return func(*args, **kwargs)
+    return _process
 
 
 class IndependentController(object):

--- a/SiteAutomations/Examples/GoogleExample.py
+++ b/SiteAutomations/Examples/GoogleExample.py
@@ -5,7 +5,7 @@ using Slack.  This controller is pretty bare-bones.
 
 from time import sleep
 from random import randint
-from Helpers.Controllers import IndependentController
+from Helpers.Controllers import IndependentController, has_kwargs
 
 
 def _do_search(driver, wait, search_term):
@@ -61,5 +61,10 @@ class ThreadedGoogleSearch(IndependentController):
     def __init__(self, models):
         self.models = models
 
-    def do_search(self, search_term):
+    # Using the @has_kwargs decorator allows keyword arguments to be
+    # passed to the method.  When you assemble a command pack for the
+    # CommandManager, just include an instance of the Kwargs object.
+    @has_kwargs
+    def do_search(self, search_term, some_kwarg='some value'):
+        print some_kwarg
         return _do_search(self.driver, self.wait, search_term)

--- a/ThreadedExample.py
+++ b/ThreadedExample.py
@@ -14,7 +14,8 @@ from Project import Models
 # Controllers are kept in the SiteAutomations folder.
 from SiteAutomations.Examples import GoogleExample, BingExample
 # Pull in the command factory, which is the backbone to threaded automations.
-from Helpers.Commands import ThreadedCommandFactory
+# also pull in the Kwargs object for passing kwargs into commands.
+from Helpers.Commands import ThreadedCommandFactory, Kwargs
 
 # Define some controllers to pass to ThreadedCommandFactory.
 # Note that the controllers being used are subclasses of IndependentController.
@@ -33,17 +34,20 @@ search_command_1 = {
     'bing': ('bing wiki',)
 }
 
+# Each argument is passed as *args.  If you need any
+# **kwargs, just instantiate a Kwargs object with the
+# dictionary containing the **kwargs.
 search_command_2 = {
-    'google': ('star wars',),
+    'google': ('star wars', Kwargs({'some_kwarg': 'Overridden value!!!'})),
     'bing': ('star wars',)
 }
 
-# Create the threads.  Pass a function as the first parameter and
-# the command pack as the second parameter.  A Command instance
-# is returned when the threads are created.  These Command
-# objects are used to start the threads.
-cmd1 = cmd_factory.create_command(lambda controller, search_term: controller.do_search(search_term), search_command_1)
-cmd2 = cmd_factory.create_command(lambda controller, search_term: controller.do_search(search_term), search_command_2)
+# Create the threads.  A Command instance is returned when
+# the threads are created.  These Command objects are used
+# to start the threads.  Pass a function as the first
+# parameter and the command pack as *args.
+cmd1 = cmd_factory.create_command(lambda controller, *search_term: controller.do_search(*search_term), search_command_1)
+cmd2 = cmd_factory.create_command(lambda controller, *search_term: controller.do_search(*search_term), search_command_2)
 
 # Start the threads.  Each search will be executed, and it will
 # only take as long as the longest loading time.

--- a/ThreadedExample.py
+++ b/ThreadedExample.py
@@ -29,6 +29,8 @@ cmd_factory = ThreadedCommandFactory(controllers, logging=False)
 
 # Register arguments to pass to each controller.  They are
 # matched by the key in the controllers dictionary.
+# The next search_command shows how to add kwargs to
+# the command pack.
 search_command_1 = {
     'google': ('google wiki',),
     'bing': ('bing wiki',)
@@ -50,7 +52,7 @@ cmd1 = cmd_factory.create_command(lambda controller, *search_term: controller.do
 cmd2 = cmd_factory.create_command(lambda controller, *search_term: controller.do_search(*search_term), search_command_2)
 
 # Start the threads.  Each search will be executed, and it will
-# only take as long as the longest loading time.
+# only take as long as the longest automation time.
 cmd1.start()
 print 'finished first search'
 sleep(3)


### PR DESCRIPTION
The CommandFactories can now handle executing methods with *_kwargs, so
long as those methods are decorated with @has_kwargs.  This is
accomplished by instantiating a Kwargs object with the dict of
*_kwargs., and adding it to the command pack that is sent to the
create_command method.  Example is in ThreadedExample.py
