### PR TITLE
Dev

### DIFF
--- a/Environment.py
+++ b/Environment.py
@@ -12,13 +12,87 @@ __SLACK_FRAMEWORK_ENV_PATH += '/.env' if __SLACK_FRAMEWORK_ENV_PATH[-1] != '/' e
 class ConfigLoader:
     def __init__(self, filepath='.env'):
         self.lines = {}
+        self.list_mode = False
+        self.list_name = None
+        self.dict_mode = False
+        self.dict_name = None
+        self.sline = None
         with open(filepath, 'r') as f:
+
             for line in f:
+                self.sline = line.strip()
                 if line[0] == '#':
                     continue
+
+                if self.dict_mode:
+                    if self.sline == self.dict_name + '{END}':
+                        self.dict_mode = False
+                        self.dict_name = None
+                        continue
+
+                    self.process_dict_line(line, self.dict_name)
+                    continue
+
+                if self.list_mode:
+                    if self.sline == '{}[END]'.format(self.list_name):
+                        self.list_name = None
+                        self.list_mode = False
+                        continue
+                    try:
+                        self.lines[self.list_name].append(self.sline)
+                    except KeyError:
+                        self.lines[self.list_name] = [self.sline]
+                    continue
+
                 if '=' in line:
-                    line_pieces = line.split('=')
-                    self.lines[line_pieces[0]] = '='.join(line_pieces[1:]).strip()
+                    self.process_key_value(line)
+                    continue
+
+                if self.sline[-3:] == '[]:':
+                    self.list_mode = True
+                    self.list_name = self.sline[:-3]
+                    continue
+
+                if self.sline[-3:] == '{}:':
+                    self.dict_mode = True
+                    self.dict_name = self.sline[:-3]
+                    continue
+
+    def check_for_list_mode(self, line):
+        self.list_name = self.sline[:-3]
+        self.list_mode = True if self.sline[-3:] == '[]:' else False
+        return self.list_name, self.list_mode
+
+    def check_for_dict_mode(self, line):
+        self.dict_name = self.sline[:-3]
+        self.dict_mode = True if self.sline[-3:] == '{}:' else False
+        return self.dict_name, self.dict_mode
+
+    def get_key_value(self, line):
+        line_pieces = self.sline.split('=')
+        key = line_pieces[0]
+        # Safely grab the value.  If the value contains an = symbol, it should
+        # not get mangled, and data should not be missing
+        value = '='.join(line_pieces[1:]).strip()
+
+        return key, value
+
+    def process_dict_line(self, line, dict_name):
+        key, value = self.get_key_value(line)
+        try:
+            self.lines[dict_name][key] = value
+        except KeyError:
+            self.lines[dict_name] = {key: value}
+        return self
+
+    def process_key_value(self, line):
+        key, value = self.get_key_value(line)
+        self.add_root_key(key, value)
+        return self
+
+    def add_root_key(self, key, value):
+        self.lines[key] = value
+        return self
 
     def get(self, variable_name):
         """

--- a/Environment.py
+++ b/Environment.py
@@ -112,18 +112,21 @@ class ConfigLoader:
 __SLACK_FRAMEWORK_RESOURCE_LOADER = ConfigLoader(filepath=__SLACK_FRAMEWORK_ENV_PATH)
 
 
-def env(variable_name):
+def env(variable_name, func=lambda x: x if x else x):
     """
-    Get the corresponding environment variable.
+    Get the corresponding environment variable.  Pass a function
+    like `int` or `bool` as the `type_hint` keyword argument to
+    automatically run that function on the output.
 
     Args:
         variable_name: string
+        func: function
 
     Returns:
         string
     """
 
-    return __SLACK_FRAMEWORK_RESOURCE_LOADER.get(variable_name)
+    return func(__SLACK_FRAMEWORK_RESOURCE_LOADER.get(variable_name))
 
 
 def env_driver(browser):
@@ -136,6 +139,7 @@ def env_driver(browser):
     Returns:
         selenium WebDriver
     """
+    
     from selenium import webdriver
 
     the_driver = False

--- a/Environment.py
+++ b/Environment.py
@@ -21,9 +21,12 @@ class ConfigLoader:
 
             for line in f:
                 self.sline = line.strip()
+
+                # Handle comments.
                 if line[0] == '#':
                     continue
 
+                # Handle dict mode.
                 if self.dict_mode:
                     if self.sline == self.dict_name + '{END}':
                         if self.dict_name not in self.lines.keys():
@@ -35,6 +38,7 @@ class ConfigLoader:
                     self.process_dict_line(line, self.dict_name)
                     continue
 
+                # Handle list mode.
                 if self.list_mode:
                     if self.sline == '{}[END]'.format(self.list_name):
                         if self.list_name not in self.lines.keys():
@@ -48,31 +52,66 @@ class ConfigLoader:
                         self.lines[self.list_name] = [self.sline]
                     continue
 
+                # Handle key=value lines.
                 if '=' in line:
                     self.process_key_value(line)
                     continue
 
+                # Handle list definitions.
                 if self.sline[-3:] == '[]:':
                     self.list_mode = True
                     self.list_name = self.sline[:-3]
                     continue
 
+                # Handle dict definitions.
                 if self.sline[-3:] == '{}:':
                     self.dict_mode = True
                     self.dict_name = self.sline[:-3]
                     continue
 
     def check_for_list_mode(self, line):
+        """
+        Check to see if the line is defining a list or not.  If it does, it will return
+        the lists name and the bool representing whether it is in list mode or not.
+
+        Args:
+            line:
+
+        Returns:
+            tuple
+        """
+
         self.list_name = self.sline[:-3]
         self.list_mode = True if self.sline[-3:] == '[]:' else False
         return self.list_name, self.list_mode
 
     def check_for_dict_mode(self, line):
+        """
+        Check to see if the line is defining a dictionary or not.  If it does, it will return
+        the dictionaries name and the bool representing whether it is in dict mode or not.
+
+        Args:
+            line:
+
+        Returns:
+            tuple
+        """
+
         self.dict_name = self.sline[:-3]
         self.dict_mode = True if self.sline[-3:] == '{}:' else False
         return self.dict_name, self.dict_mode
 
     def get_key_value(self, line):
+        """
+        Get the key and value from the given line, assuming it's separated by the first = sign.
+
+        Args:
+            line:
+
+        Returns:
+
+        """
+
         line_pieces = self.sline.split('=')
         key = line_pieces[0]
         # Safely grab the value.  If the value contains an = symbol, it should
@@ -82,6 +121,17 @@ class ConfigLoader:
         return key, value
 
     def process_dict_line(self, line, dict_name):
+        """
+        Process a line that occurs within a dict that is being defined in the .env file.
+
+        Args:
+            line:
+            dict_name:
+
+        Returns:
+            self
+        """
+
         key, value = self.get_key_value(line)
         try:
             self.lines[dict_name][key] = value
@@ -90,11 +140,32 @@ class ConfigLoader:
         return self
 
     def process_key_value(self, line):
+        """
+        Process a key=value from the given line.
+
+        Args:
+            line:
+
+        Returns:
+            self
+        """
+
         key, value = self.get_key_value(line)
         self.add_root_key(key, value)
         return self
 
     def add_root_key(self, key, value):
+        """
+        Add a key to self.lines with the given value.
+
+        Args:
+            key:
+            value:
+
+        Returns:
+            self
+        """
+
         self.lines[key] = value
         return self
 

--- a/Environment.py
+++ b/Environment.py
@@ -26,6 +26,8 @@ class ConfigLoader:
 
                 if self.dict_mode:
                     if self.sline == self.dict_name + '{END}':
+                        if self.dict_name not in self.lines.keys():
+                            self.lines[self.dict_name] = {}
                         self.dict_mode = False
                         self.dict_name = None
                         continue
@@ -35,6 +37,8 @@ class ConfigLoader:
 
                 if self.list_mode:
                     if self.sline == '{}[END]'.format(self.list_name):
+                        if self.list_name not in self.lines.keys():
+                            self.lines[self.list_name] = []
                         self.list_name = None
                         self.list_mode = False
                         continue

--- a/Environment.py
+++ b/Environment.py
@@ -139,7 +139,7 @@ def env_driver(browser):
     Returns:
         selenium WebDriver
     """
-    
+
     from selenium import webdriver
 
     the_driver = False

--- a/Helpers/Controllers.py
+++ b/Helpers/Controllers.py
@@ -22,7 +22,6 @@ for __ in range(1, 61):
         sleep({})
         return function_result
     return wait_decorator'''.format(__, __, __))
-print('done')
 
 
 def randomly_waits(function):

--- a/Helpers/Controllers.py
+++ b/Helpers/Controllers.py
@@ -4,6 +4,27 @@ from .Commands import Kwargs
 from selenium.webdriver.support.wait import WebDriverWait
 
 
+# Generate a bunch of decorators for waiting up to 60 seconds.
+for __ in range(1, 61):
+    exec('''def waits{}(function):
+    """
+    A decorator for waiting {} second after function execution.  Great for waiting between actions.
+
+    Args:
+        function: function
+
+    Returns:
+        wait_decorator: function
+    """
+
+    def wait_decorator(*args, **kwargs):
+        function_result = function(*args, **kwargs)
+        sleep({})
+        return function_result
+    return wait_decorator'''.format(__, __, __))
+print('done')
+
+
 def randomly_waits(function):
     """
     A decorator for waiting a random amount of time(0.1-3.01 seconds) after function execution.
@@ -22,60 +43,6 @@ def randomly_waits(function):
         sleep(uniform(0.01, 3.01))
         return function_result
     return random_wait_decorator
-
-
-def waits1(function):
-    """
-    A decorator for waiting 1 second after function execution.  Great for waiting between actions.
-
-    Args:
-        function: function
-
-    Returns:
-        wait_decorator: function
-    """
-
-    def wait_decorator(*args, **kwargs):
-        function_result = function(*args, **kwargs)
-        sleep(1)
-        return function_result
-    return wait_decorator
-
-
-def waits2(function):
-    """
-    A decorator for waiting 2 seconds after function execution.  Great for waiting between actions.
-
-    Args:
-        function: function
-
-    Returns:
-        wait_decorator: function
-    """
-
-    def wait_decorator(*args, **kwargs):
-        function_result = function(*args, **kwargs)
-        sleep(2)
-        return function_result
-    return wait_decorator
-
-
-def waits3(function):
-    """
-    A decorator for waiting 3 seconds after function execution.  Great for waiting between actions.
-
-    Args:
-        function: function
-
-    Returns:
-        wait_decorator: function
-    """
-
-    def wait_decorator(*args, **kwargs):
-        function_result = function(*args, **kwargs)
-        sleep(3)
-        return function_result
-    return wait_decorator
 
 
 def has_kwargs(function):


### PR DESCRIPTION
- Removed the wait1, wait2, wait3 decorators and replaced it with code that dynamically defines the same functions, but up to 60.  This will usually throw an error in IDEs like PyCharm, but the functions will still import correctly.
- Created a list mode and dict mode for the `ConfigLoader`(`env`) so that lists and dictionaries can be defined within the .env file itself.  That way you don’t have to worry about splitting up strings or anything like that.
- `env` now has a keyword argument, `func`, that can be used to set a callback function that will operate on the `env` functions returned value.  It can be used to convert strings to integers or even to set up more complex transformations. Example: `env(‘EMAIL_PORT’, func=int)`.
